### PR TITLE
functorish class

### DIFF
--- a/Data/TASequence.hs
+++ b/Data/TASequence.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE GADTs,TypeSynonymInstances,FlexibleInstances #-}
+{-# LANGUAGE GADTs,TypeSynonymInstances,FlexibleInstances,RankNTypes #-}
 
 
 
@@ -37,7 +37,7 @@
 -- Paper: <http://homepages.cwi.nl/~ploeg/zseq.pdf>
 -- Talk : <http://www.youtube.com/watch?v=_XoI65Rxmss>
 -----------------------------------------------------------------------------
-module Data.TASequence(TASequence(..), TAViewL(..), TAViewR(..)) where
+module Data.TASequence(TASequence(..), TAViewL(..), TAViewR(..),Maps(..)) where
 
 import Control.Category
 import Prelude hiding ((.),id)
@@ -89,7 +89,8 @@ data TAViewR s c x y where
    TAEmptyR  :: TAViewR s c x x
    (:>)     :: s c x y -> c y z -> TAViewR s c x z
 
-
+class Maps s where
+  maps :: (forall x y. c x y -> d x y) -> s c x y -> s d x y
 
 instance TASequence s => Category (s c) where
   id = tempty

--- a/Data/TASequence/BinaryTree.hs
+++ b/Data/TASequence/BinaryTree.hs
@@ -34,3 +34,7 @@ instance TASequence BinaryTree where
   tviewl (Node (Leaf c) r)   = c :< r
   tviewl (Node Empty r)      = tviewl r
                         
+instance Maps BinaryTree where
+  maps phi Empty = Empty
+  maps phi (Leaf c) = Leaf (phi c)
+  maps phi (Node b b') = Node (maps phi b) (maps phi b')

--- a/Data/TASequence/CatQueue.hs
+++ b/Data/TASequence/CatQueue.hs
@@ -46,3 +46,7 @@ instance TASequence q => TASequence (ToCatQueue q) where
      CN x q :< t  -> CN x (q `snoc` linkAll t)
     snoc q C0  = q
     snoc q r   = q |> r
+
+instance Maps q => ToCatQueue q where
+  maps phi C0 = C0
+  maps phi (CN c q) = CN (phi c) (maps (maps phi) q)

--- a/Data/TASequence/ConsList.hs
+++ b/Data/TASequence/ConsList.hs
@@ -27,3 +27,8 @@ instance TASequence ConsList where
   (<|) = Cons
   tviewl CNil = TAEmptyL
   tviewl (Cons h t) = h :< t
+
+instance Maps ConsList where
+  maps phi CNil = CNil
+  maps phi (Cons c s) = Cons  (phi c) (maps phi s)
+  

--- a/Data/TASequence/FastQueue.hs
+++ b/Data/TASequence/FastQueue.hs
@@ -48,3 +48,5 @@ instance TASequence FastQueue where
  tviewl (RQ CNil SNil CNil) = TAEmptyL
  tviewl (RQ (h `Cons` t) f a) = h :< queue t f a
 
+instance Maps FastQueue where
+  maps phi (RQ a b c) = RQ (maps phi a) (maps phi b) (maps phi c)

--- a/Data/TASequence/FingerTree.hs
+++ b/Data/TASequence/FingerTree.hs
@@ -31,7 +31,6 @@ data FingerTree r a b where
   Single :: r a b -> FingerTree r a b
   Deep   :: !(Digit r a b) -> FingerTree (Node r) b c -> !(Digit r c d) -> FingerTree r a d
 
-
 data Node r a b where
   Node2 :: r a b -> r b c -> Node r a c
   Node3 :: r a b -> r b c -> r c d -> Node r a d
@@ -187,3 +186,17 @@ nodes (a ::: b ::: c ::: d ::: ZNil) = Node2 a b ::: Node2 c d ::: ZNil
 nodes (a ::: b ::: c ::: xs) = Node3 a b c ::: nodes xs
 
 
+instance Maps Node where
+  maps phi (Node2 r s) = Node2 (phi r) (phi s)
+  maps phi (Node3 r s t) = Node3 (phi r) (phi s) (phi t)
+  
+instance Maps Digit  where
+  maps phi (One r) = One (phi r) 
+  maps phi (Two r s) = Two (phi r) (phi s)
+  maps phi (Three r s t) = Three (phi r) (phi s) (phi t)
+  maps phi (Four r s t u) = Four (phi r) (phi s) (phi t) (phi u)
+
+instance Maps FingerTree where
+  maps phi Empty = Empty
+  maps phi (Single s) = Single (phi s)
+  maps phi (Deep d f d') = Deep (maps phi d) (maps (maps phi) f) (maps phi d')

--- a/Data/TASequence/Queue.hs
+++ b/Data/TASequence/Queue.hs
@@ -56,4 +56,9 @@ instance TASequence Queue where
            buf2queue (B1 a)        = Q1 a
            buf2queue(B2 (a :* b))  = QN (B1 a) Q0 (B1 b)
   
-             
+instance Maps P where
+  maps phi (a :* b) = phi a :* phi b
+  
+instance Maps B where
+  maps phi (B1 c) = B1 (phi c)
+  maps phi (B2 p) = B2 (maps phi p)

--- a/Data/TASequence/SnocList.hs
+++ b/Data/TASequence/SnocList.hs
@@ -28,3 +28,7 @@ instance TASequence SnocList where
   (|>) = Snoc
   tviewr SNil = TAEmptyR
   tviewr (Snoc p l) = p :> l
+
+instance Maps SnocList where
+  maps phi SNil = SNil
+  maps phi (Snoc s c) = Snoc (maps phi s) (phi c)

--- a/Data/TASequence/ToCatQueue.hs
+++ b/Data/TASequence/ToCatQueue.hs
@@ -46,3 +46,7 @@ instance TASequence q => TASequence (ToCatQueue q) where
      CN x q :< t  -> CN x (q `snoc` linkAll t)
     snoc q C0  = q
     snoc q r   = q |> r
+
+instance Maps q => Maps (ToCatQueue q) where
+  maps phi C0 = C0
+  maps phi (CN c q) = CN (phi c) (maps (maps phi) q)

--- a/type-aligned.cabal
+++ b/type-aligned.cabal
@@ -14,7 +14,7 @@ Category:            Data, Data Structures
 Tested-With:         GHC==7.6.3
 Library
   Build-Depends: base >= 2 && <= 6
-  Exposed-modules: Data.TASequence.BinaryTree, Data.TASequence.Class, Data.TASequence.ConsList, Data.TASequence.FastCatQueue,  Data.TASequence.FastQueue, Data.TASequence.FingerTree, Data.TASequence.Queue, Data.TASequence.SnocList, Data.TASequence.ToCatQueue
+  Exposed-modules: Data.TASequence.BinaryTree, Data.TASequence, Data.TASequence.ConsList, Data.TASequence.FastCatQueue,  Data.TASequence.FastQueue, Data.TASequence.FingerTree, Data.TASequence.Queue, Data.TASequence.SnocList, Data.TASequence.ToCatQueue
 
   Extensions:	 GADTs, TypeSynonymInstances,FlexibleInstances, ViewPatterns, TypeOperators
 


### PR DESCRIPTION
I'm not sure what this Functor-like class should be called, 

```
 class Maps phi where -- laws like Functor
   maps :: (forall x y . p x y -> q x y) -> phi p a b -> phi q a b 
```

but it needs to be threaded through starting with 

```
 instance Maps Cons where
   maps phi Nil = Nil
   maps phi (Cons a bs) = Cons (phi a) (maps phi bs)
   {-# INLINABLE maps #-}
```

if we are to be able to use it with `type FastTCQueue =  ToCatQueue FastQueue`

I was trying to write a `FreeT` module, or possibly a more specialized one https://github.com/michaelt/remorse/blob/master/Remorse/Free.hs . (My ultimate purpose might be visible here https://github.com/michaelt/series).  I hadn't realized `type-aligned` was on hackage,  so I made a little replica of some of it . 

But in trying to translate over to `type-aligned` I was immediately needing something like `maps` to write several fundamental functions, e.g. `hoistFreeT`, `transFreeT` (to use the hideous names from the `free` package), and to write the MFunctor and MMonad instances.  The same problem arose in the little prelude I started to write https://github.com/michaelt/remorse/blob/master/Remorse/Prelude.hs#L240 which is a little closer to my ultimate purpose.  I might be able to get around some of these, but since the constructors for `ToCatQueue` and `FastQueue` aren't exposed, the most natural approaches were blocked -- to defined things directly, or with my own `Maps` class.
