### PR TITLE
Remove shady Category instance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.stack-work/
+dist/
+*.o
+*.hi

--- a/Data/TASequence.hs
+++ b/Data/TASequence.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE GADTs,TypeSynonymInstances,FlexibleInstances,Rank2Types #-}
+{-# LANGUAGE GADTs,Rank2Types #-}
 
 
 
@@ -135,7 +135,3 @@ data TAViewL s c x y where
 data TAViewR s c x y where
    TAEmptyR  :: TAViewR s c x x
    (:>)     :: s c x y -> c y z -> TAViewR s c x z
-
-instance TASequence s => Category (s c) where
-  id = tempty
-  (.) = flip (><)

--- a/Data/TASequence/BinaryTree.hs
+++ b/Data/TASequence/BinaryTree.hs
@@ -17,6 +17,7 @@
 -----------------------------------------------------------------------------
 module Data.TASequence.BinaryTree(module Data.TASequence, BinaryTree) where
 
+import  Control.Category
 import  Data.TASequence
 
 data BinaryTree c x y where
@@ -37,3 +38,7 @@ instance TASequence BinaryTree where
   tmap phi Empty = Empty
   tmap phi (Leaf c) = Leaf (phi c)
   tmap phi (Node b b') = Node (tmap phi b) (tmap phi b')
+
+instance Category (BinaryTree c) where
+  id = tempty
+  (.) = flip (><)

--- a/Data/TASequence/ConsList.hs
+++ b/Data/TASequence/ConsList.hs
@@ -15,6 +15,7 @@
 --
 -----------------------------------------------------------------------------
 module Data.TASequence.ConsList(module Data.TASequence,ConsList(..)) where
+import Control.Category
 import Data.TASequence
 
 data ConsList c x y where
@@ -28,4 +29,6 @@ instance TASequence ConsList where
   tviewl CNil = TAEmptyL
   tviewl (Cons h t) = h :< t
 
-  
+instance Category (ConsList c) where
+  id = tempty
+  (.) = flip (><)

--- a/Data/TASequence/FastQueue.hs
+++ b/Data/TASequence/FastQueue.hs
@@ -19,6 +19,7 @@
 
 module Data.TASequence.FastQueue(module Data.TASequence, FastQueue) where
 
+import Control.Category
 import Data.TASequence
 import Data.TASequence.ConsList
 import Data.TASequence.SnocList
@@ -49,3 +50,7 @@ instance TASequence FastQueue where
  tviewl (RQ (h `Cons` t) f a) = h :< queue t f a
 
  tmap phi (RQ a b c) = RQ (tmap phi a) (tmap phi b) (tmap phi c)
+
+instance Category (FastQueue c) where
+  id = tempty
+  (.) = flip (><)

--- a/Data/TASequence/FingerTree.hs
+++ b/Data/TASequence/FingerTree.hs
@@ -22,7 +22,7 @@
 module Data.TASequence.FingerTree (module Data.TASequence, FingerTree ) where
 
 
-
+import Control.Category
 import Data.TASequence
 
 
@@ -71,7 +71,9 @@ instance TASequence FingerTree where
   tmap f (Single a) = Single (f a)
   tmap f (Deep l m r) = Deep (mapd f l) (tmap (mapn f) m) (mapd f r)
 
-
+instance Category (FingerTree c) where
+  id = tempty
+  (.) = flip (><)
 
 toTree :: Digit r a b -> FingerTree r a b
 toTree (One a)         = Single a
@@ -146,7 +148,7 @@ fromListR (c :::< b :::< a :::< ZNilR) = Three a b c
 fromListR (d :::< c :::< b :::< a :::< ZNilR) = Four a b c d
 
 
-rev = toList . fromListR 
+rev = toList Prelude.. fromListR
 
 
 

--- a/Data/TASequence/Queue.hs
+++ b/Data/TASequence/Queue.hs
@@ -21,6 +21,7 @@
 -----------------------------------------------------------------------------
 module Data.TASequence.Queue(module Data.TASequence,Queue)  where
 
+import Control.Category
 import Data.TASequence
 
 data P c a b where
@@ -58,6 +59,10 @@ instance TASequence Queue where
   tmap f Q0 = Q0
   tmap f (Q1 x) = Q1 (f x)
   tmap f (QN l m r) = QN (tmapb f l) (tmap (tmapp f) m) (tmapb f r)
+
+instance Category (Queue c) where
+  id = tempty
+  (.) = flip (><)
 
 tmapp :: (forall x y. c x y -> d x y) -> P c x y -> P d x y
 tmapp phi (a :* b) = phi a :* phi b

--- a/Data/TASequence/SnocList.hs
+++ b/Data/TASequence/SnocList.hs
@@ -16,6 +16,7 @@
 
 module Data.TASequence.SnocList(module Data.TASequence,SnocList(..))  where
 
+import Control.Category
 import Data.TASequence
 
 data SnocList c x y where
@@ -30,3 +31,7 @@ instance TASequence SnocList where
   tviewr (Snoc p l) = p :> l
   tmap phi SNil = SNil
   tmap phi (Snoc s c) = Snoc (tmap phi s) (phi c)
+
+instance Category (SnocList c) where
+  id = tempty
+  (.) = flip (><)

--- a/Data/TASequence/ToCatQueue.hs
+++ b/Data/TASequence/ToCatQueue.hs
@@ -22,6 +22,7 @@
 module Data.TASequence.ToCatQueue(module Data.TASequence,ToCatQueue) where
 
 
+import Control.Category
 import Data.TASequence
 
 -- | The catenable queue type. The first type argument is the 
@@ -49,3 +50,7 @@ instance TASequence q => TASequence (ToCatQueue q) where
 
  tmap phi C0 = C0
  tmap phi (CN c q) = CN (phi c) (tmap (tmap phi) q)
+
+instance TASequence q => Category (ToCatQueue q c) where
+  id = tempty
+  (.) = flip (><)


### PR DESCRIPTION
Previously, we had

```haskell
instance TASequence s => Category (s c)
```

which would overlap all sorts of potential `Category` instances.
Remove that, and give each type-aligned sequence its own
`Category` instance.