### PR TITLE
Fix invariant in FastQueue, more laziness in ToCatQueue

### DIFF
--- a/Data/TASequence/FastQueue.hs
+++ b/Data/TASequence/FastQueue.hs
@@ -43,7 +43,7 @@ queue f r (h `Cons` t) = RQ f r t
 
 instance TASequence FastQueue where
  tempty = RQ CNil SNil CNil
- tsingleton x = let c = tsingleton x in queue c SNil c
+ tsingleton x = let c = tsingleton x in RQ c SNil c
  (RQ f r a) |> x = queue f (r `Snoc` x) a
 
  tviewl (RQ CNil SNil CNil) = TAEmptyL

--- a/Data/TASequence/ToCatQueue.hs
+++ b/Data/TASequence/ToCatQueue.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE GADTs, PolyKinds #-}
+{-# LANGUAGE GADTs, PolyKinds, ScopedTypeVariables #-}
 
 
 
@@ -39,14 +39,14 @@ instance TASequence q => TASequence (ToCatQueue q) where
  (CN x q)  >< ys  = CN x (q |> ys)
 
  tviewl C0        = TAEmptyL
- tviewl (CN h t)  = h :< linkAll t
-   where 
-    linkAll :: TASequence q =>  q (ToCatQueue q c) a b -> ToCatQueue q c a b
-    linkAll v = case tviewl v of
-     TAEmptyL     -> C0
-     CN x q :< t  -> CN x (q `snoc` linkAll t)
-    snoc q C0  = q
-    snoc q r   = q |> r
+ tviewl (CN x q)  = x :< case tviewl q of
+   TAEmptyL -> C0
+   t :< q'  -> linkAll t q'
+   where
+   linkAll :: ToCatQueue q c x y -> q (ToCatQueue q c) y z -> ToCatQueue q c x z
+   linkAll t@(CN x q) q' = case tviewl q' of
+     TAEmptyL -> t
+     h :< t'  -> CN x (q |> linkAll h t')
 
  tmap phi C0 = C0
  tmap phi (CN c q) = CN (phi c) (tmap (tmap phi) q)


### PR DESCRIPTION
Example code that triggered invariant violation error in 0.9.6:
ghci> let x = tviewl (tsingleton id :: FastQueue (->) () ())
ghci> :force x
*** Exception: Invariant |a| = |f| - (|r| - 1) broken

Lengths of queue components (L, R, L') should satisfy |L'| = |L| - |R|, as defined in Okasaki's paper.
Resolution was as simple as defining
`tsingleton x = tempty |> x`
but one can evaluate it to
`let c = tsingleton x in RQ c SNil c`
so that's the way it's defined in this patch.

I believe that the reason for this bug to stay unnoticed is that FastQueue is hardly ever used by client code directly - only through a ToCatQueue wrapper which makes no use of FastQueue's `tsingleton` method.