### PR TITLE
fold, foldMap, foldl, & foldr

### DIFF
--- a/Data/TASequence.hs
+++ b/Data/TASequence.hs
@@ -114,6 +114,13 @@ class TASequence (s :: (k -> k -> *) -> k -> k -> *) where
   -- >   h :< t -> f h >>> tfoldMap f t
   tfoldMap   :: Category d => (forall x y. c x y -> d x y) -> s c x y -> d x y
 
+  -- | Combine all elements in a type aligned sequence using a 'Category' instance.
+  --
+  -- Default definition:
+  --
+  -- > tfold = tfoldMap id
+  tfold      :: Category c => s c x y -> c x y
+
   l |> r = l >< tsingleton r
   l <| r = tsingleton l >< r
   l >< r = case tviewl l of
@@ -139,6 +146,8 @@ class TASequence (s :: (k -> k -> *) -> k -> k -> *) where
   tfoldMap f q = case tviewl q of
     TAEmptyL -> id
     h :< t -> f h >>> tfoldMap f t
+
+  tfold = tfoldMap id
 
 data TAViewL s c x y where
    TAEmptyL  :: TAViewL s c x x

--- a/Data/TASequence.hs
+++ b/Data/TASequence.hs
@@ -122,7 +122,7 @@ class TASequence (s :: (k -> k -> *) -> k -> k -> *) where
   tfold      :: Category c => s c x y -> c x y
 
   -- | Right-associative fold of a type aligned sequence.
-  tfoldr     :: (forall x y z . c y z -> d x y -> d x z) -> d p q -> s c q r -> d p r
+  tfoldr     :: (forall x y z . c x y -> d y z -> d x z) -> d q r -> s c p q -> d p r
 
   l |> r = l >< tsingleton r
   l <| r = tsingleton l >< r
@@ -163,9 +163,9 @@ data TAViewR s c x y where
    (:>)     :: s c x y -> c y z -> TAViewR s c x z
 
 
--- Approach due to Joachim Breitner: https://stackoverflow.com/a/30986119/88018
-newtype Endo h c d = Endo { appEndo :: forall b. h b c -> h b d  }
+-- Approach adapted from Joachim Breitner: https://stackoverflow.com/a/30986119/88018
+newtype Endo h c d = Endo { appEndo :: forall b. h d b -> h c b  }
 
 instance Category (Endo h) where
     id = Endo id
-    Endo f1 . Endo f2 = Endo (f1 . f2)
+    Endo f1 . Endo f2 = Endo (f2 . f1)

--- a/Data/TASequence.hs
+++ b/Data/TASequence.hs
@@ -104,7 +104,16 @@ class TASequence (s :: (k -> k -> *) -> k -> k -> *) where
   -- >    TAEmptyL -> tempty
   -- >    h :< t -> f h <| tmap f t
   tmap       :: (forall x y. c x y -> d x y) -> s c x y -> s d x y
-  
+
+  -- | Apply a function to all elements in a type aligned sequence, and combine them using a 'Category' instance.
+  --
+  -- Default definition:
+  --
+  -- > tfoldMap f q = case tviewl q of
+  -- >   TAEmptyL -> id
+  -- >   h :< t -> f h >>> tfoldMap f t
+  tfoldMap   :: Category d => (forall x y. c x y -> d x y) -> s c x y -> d x y
+
   l |> r = l >< tsingleton r
   l <| r = tsingleton l >< r
   l >< r = case tviewl l of
@@ -127,6 +136,9 @@ class TASequence (s :: (k -> k -> *) -> k -> k -> *) where
     TAEmptyL -> tempty
     h :< t -> f h <| tmap f t
 
+  tfoldMap f q = case tviewl q of
+    TAEmptyL -> id
+    h :< t -> f h >>> tfoldMap f t
 
 data TAViewL s c x y where
    TAEmptyL  :: TAViewL s c x x

--- a/Data/TASequence/BinaryTree.hs
+++ b/Data/TASequence/BinaryTree.hs
@@ -19,6 +19,7 @@ module Data.TASequence.BinaryTree(module Data.TASequence, BinaryTree) where
 
 import  Control.Category
 import  Data.TASequence
+import  Prelude hiding (id)
 
 data BinaryTree c x y where
   Empty :: BinaryTree c x x
@@ -38,6 +39,10 @@ instance TASequence BinaryTree where
   tmap phi Empty = Empty
   tmap phi (Leaf c) = Leaf (phi c)
   tmap phi (Node b b') = Node (tmap phi b) (tmap phi b')
+
+  tfoldMap phi Empty      = id
+  tfoldMap phi (Leaf c)   = phi c
+  tfoldMap phi (Node a b) = tfoldMap phi a >>> tfoldMap phi b
 
 instance Category (BinaryTree c) where
   id = tempty

--- a/Data/TASequence/FingerTree.hs
+++ b/Data/TASequence/FingerTree.hs
@@ -24,6 +24,7 @@ module Data.TASequence.FingerTree (module Data.TASequence, FingerTree ) where
 
 import Control.Category
 import Data.TASequence
+import Prelude hiding (id)
 
 
 data FingerTree r a b where
@@ -70,6 +71,10 @@ instance TASequence FingerTree where
   tmap f Empty = Empty
   tmap f (Single a) = Single (f a)
   tmap f (Deep l m r) = Deep (mapd f l) (tmap (mapn f) m) (mapd f r)
+
+  tfoldMap f Empty = id
+  tfoldMap f (Single a) = f a
+  tfoldMap f (Deep l m r) = foldMapd f l >>> tfoldMap (foldMapn f) m >>> foldMapd f r
 
 instance Category (FingerTree c) where
   id = tempty
@@ -194,11 +199,19 @@ nodes (a ::: b ::: c ::: xs) = Node3 a b c ::: nodes xs
 mapn :: (forall x y. c x y -> d x y) -> Node c x y -> Node d x y
 mapn phi (Node2 r s) = Node2 (phi r) (phi s)
 mapn phi (Node3 r s t) = Node3 (phi r) (phi s) (phi t)
-  
+
+foldMapn :: Category d => (forall x y. c x y -> d x y) -> Node c x y -> d x y
+foldMapn phi (Node2 r s) = phi r >>> phi s
+foldMapn phi (Node3 r s t) = phi r >>> phi s >>> phi t
+
 mapd :: (forall x y. c x y -> d x y) -> Digit c x y -> Digit d x y
 mapd phi (One r) = One (phi r) 
 mapd phi (Two r s) = Two (phi r) (phi s)
 mapd phi (Three r s t) = Three (phi r) (phi s) (phi t)
 mapd phi (Four r s t u) = Four (phi r) (phi s) (phi t) (phi u)
 
-
+foldMapd :: Category d => (forall x y. c x y -> d x y) -> Digit c x y -> d x y
+foldMapd phi (One r) = phi r
+foldMapd phi (Two r s) = phi r >>> phi s
+foldMapd phi (Three r s t) = phi r >>> phi s >>> phi t
+foldMapd phi (Four r s t u) = phi r >>> phi s >>> phi t >>> phi u

--- a/Data/TASequence/SnocList.hs
+++ b/Data/TASequence/SnocList.hs
@@ -18,6 +18,7 @@ module Data.TASequence.SnocList(module Data.TASequence,SnocList(..))  where
 
 import Control.Category
 import Data.TASequence
+import Prelude hiding (id)
 
 data SnocList c x y where
   SNil :: SnocList c x x
@@ -31,6 +32,9 @@ instance TASequence SnocList where
   tviewr (Snoc p l) = p :> l
   tmap phi SNil = SNil
   tmap phi (Snoc s c) = Snoc (tmap phi s) (phi c)
+
+  tfoldMap phi SNil = id
+  tfoldMap phi (Snoc s c) = tfoldMap phi s >>> phi c
 
 instance Category (SnocList c) where
   id = tempty

--- a/Data/TASequence/ToCatQueue.hs
+++ b/Data/TASequence/ToCatQueue.hs
@@ -24,6 +24,7 @@ module Data.TASequence.ToCatQueue(module Data.TASequence,ToCatQueue) where
 
 import Control.Category
 import Data.TASequence
+import Prelude hiding (id)
 
 -- | The catenable queue type. The first type argument is the 
 -- type of the queue we use (|>)
@@ -50,6 +51,9 @@ instance TASequence q => TASequence (ToCatQueue q) where
 
  tmap phi C0 = C0
  tmap phi (CN c q) = CN (phi c) (tmap (tmap phi) q)
+
+ tfoldMap phi C0 = id
+ tfoldMap phi (CN c q) = phi c >>> tfoldMap (tfoldMap phi) q
 
 instance TASequence q => Category (ToCatQueue q c) where
   id = tempty


### PR DESCRIPTION
This PR introduces `tfold`, `tfoldMap`, `tfoldl`, & `tfoldr` operations, by analogy with `Foldable`’s `fold`, `foldMap`, `foldl`, & `foldr`, but (in the case of `tfold` & `tfoldMap`) using a `Category` instance instead of a `Monoid` instance to combine elements.

As a fun aside, since all the various type-aligned sequence types have `Category` instances, we can use this to reconstruct one kind of sequence with another by using `tfoldMap tsingleton`. We can also do `tfoldr (<|) tempty` and `tfoldl (|>) tempty`, which is quite satisfying.

I think this resolves #4, tho I’d note that the types I arrived at differ from the ones mentioned here: https://stackoverflow.com/questions/30985070/how-can-i-express-foldr-in-terms-of-foldmap-for-type-aligned-sequences — in particular, the types mentioned there don’t admit the typical recursive definitions of left & right folds for `ConsList`, whereas the ones I’ve used do; and intuitively, `tfoldr`’s `z` parameter is its terminal value, whereas `tfoldl`’s `z` is its initial value.

I attempted to follow `base`’s definition of `foldl` with a `Dual` newtype, but I found that difficult; I think we would need `Dual (Endo (Dual h))` rather than `Dual (Endo h)`, tho I’m not at all certain of that. Nevertheless, I’m pretty satisfied with the result.

Thank you for your time & consideration!