### PR TITLE
Fix FastQueue

### DIFF
--- a/Data/TASequence/Any.hs
+++ b/Data/TASequence/Any.hs
@@ -1,0 +1,33 @@
+{-# LANGUAGE CPP #-}
+#if __GLASGOW_HASKELL__ >= 704
+{-# LANGUAGE Trustworthy #-}
+#endif
+-- We suppress this warning because otherwise GHC complains
+-- about the newtype constructor not being used.
+#if __GLASGOW_HASKELL__ >= 800
+{-# OPTIONS_GHC -Wno-unused-top-binds #-}
+#endif
+
+-- | It's safe to coerce /to/ 'Any' as long as you don't
+-- coerce back. We define our own 'Any' instead of using
+-- the one in "GHC.Exts" directly to ensure that this
+-- module doesn't clash with one making the opposite
+-- assumption. We use a newtype rather than a closed type
+-- family with no instances because the latter weren't supported
+-- until 8.0.
+module Data.TASequence.Any
+  ( Any
+  , AnyCat
+  , toAnyConsList
+  ) where
+
+import Data.TASequence.ConsList
+import Unsafe.Coerce
+import qualified GHC.Exts as E
+
+newtype Any = Any E.Any
+newtype AnyCat a b = AnyCat E.Any
+
+-- | Convert a list of anything to a list of 'Any'.
+toAnyConsList :: ConsList tc a c -> ConsList AnyCat Any c
+toAnyConsList = unsafeCoerce

--- a/type-aligned.cabal
+++ b/type-aligned.cabal
@@ -15,6 +15,7 @@ Tested-With:         GHC==7.6.3
 Library
   Build-Depends: base >= 2 && <= 6
   Exposed-modules: Data.TASequence.BinaryTree, Data.TASequence, Data.TASequence.ConsList, Data.TASequence.FastCatQueue,  Data.TASequence.FastQueue, Data.TASequence.FingerTree, Data.TASequence.Queue, Data.TASequence.SnocList, Data.TASequence.ToCatQueue
+  Other-modules: Data.TASequence.Any
 
   Extensions:	 GADTs, ViewPatterns, TypeOperators, Rank2Types
 


### PR DESCRIPTION
* There were invariant failures on empty queues. Get rid of those.
* Use a sort of fake existential type for the schedule. This allows
  GHC to unpack the queues. It also lets us avoid mapping over the
  schedule it `tmap`, improving efficiency.