### PR TITLE
Fake the existential in FastQueue

### DIFF
--- a/Data/TASequence/Any.hs
+++ b/Data/TASequence/Any.hs
@@ -1,0 +1,33 @@
+{-# LANGUAGE CPP #-}
+#if __GLASGOW_HASKELL__ >= 704
+{-# LANGUAGE Trustworthy #-}
+#endif
+-- We suppress this warning because otherwise GHC complains
+-- about the newtype constructor not being used.
+#if __GLASGOW_HASKELL__ >= 800
+{-# OPTIONS_GHC -Wno-unused-top-binds #-}
+#endif
+
+-- | It's safe to coerce /to/ 'Any' as long as you don't
+-- coerce back. We define our own 'Any' instead of using
+-- the one in "GHC.Exts" directly to ensure that this
+-- module doesn't clash with one making the opposite
+-- assumption. We use a newtype rather than a closed type
+-- family with no instances because the latter weren't supported
+-- until 8.0.
+module Data.TASequence.Any
+  ( Any
+  , AnyCat
+  , toAnyConsList
+  ) where
+
+import Data.TASequence.ConsList
+import Unsafe.Coerce
+import qualified GHC.Exts as E
+
+newtype Any = Any E.Any
+newtype AnyCat a b = AnyCat E.Any
+
+-- | Convert a list of anything to a list of 'Any'.
+toAnyConsList :: ConsList tc a c -> ConsList AnyCat Any c
+toAnyConsList = unsafeCoerce

--- a/Data/TASequence/FastQueue.hs
+++ b/Data/TASequence/FastQueue.hs
@@ -1,4 +1,8 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE GADTs, ViewPatterns, TypeOperators, PolyKinds #-}
+#if __GLASGOW_HASKELL__ >= 704
+{-# LANGUAGE Trustworthy #-}
+#endif
 
 
 -----------------------------------------------------------------------------
@@ -23,10 +27,11 @@ import Control.Category
 import Data.TASequence
 import Data.TASequence.ConsList
 import Data.TASequence.SnocList
+import Data.TASequence.Any
 
 
 revAppend l r = rotate l r CNil
--- precondtion : |a| = |f| - (|r| - 1)
+-- precondition : |a| = |f| - (|r| - 1)
 -- postcondition: |a| = |f| - |r|
 rotate :: ConsList tc a b -> SnocList tc b c -> ConsList tc c d -> ConsList tc a d
 rotate CNil  (SNil `Snoc` y) r = y `Cons` r
@@ -34,22 +39,27 @@ rotate (x `Cons` f) (r `Snoc` y) a = x `Cons` rotate f r (y `Cons` a)
 rotate f        a     r  = error "Invariant |a| = |f| - (|r| - 1) broken"
 
 data FastQueue tc a b where
-  RQ :: !(ConsList tc a b) -> !(SnocList tc b c) -> !(ConsList tc x b) -> FastQueue tc a c
+  -- We use Any instead of a proper existential to allow GHC to unpack
+  -- FastQueue and to make `tmap` more efficient.  Unfortunately, GHC still
+  -- doesn't know how to unpack existentials, though it has known how to unpack
+  -- GADTs for some time.  We do this only for the schedule, so it doesn't
+  -- weaken the correctness guarantees.
+  RQ :: !(ConsList tc a b) -> !(SnocList tc b c) -> !(ConsList AnyCat Any b) -> FastQueue tc a c
 
-queue :: ConsList tc a b -> SnocList tc b c -> ConsList tc x b -> FastQueue tc a c
+queue :: ConsList tc a b -> SnocList tc b c -> ConsList AnyCat Any b -> FastQueue tc a c
 queue f r CNil = let f' = revAppend f r 
-                 in RQ f' SNil f'
-queue f r (h `Cons` t) = RQ f r t
+                 in RQ f' SNil (toAnyConsList f')
+queue f r (h `Cons` t) = RQ f r (toAnyConsList t)
 
 instance TASequence FastQueue where
- tempty = RQ CNil SNil CNil
- tsingleton x = let c = tsingleton x in RQ c SNil c
+ tempty = RQ CNil SNil (toAnyConsList CNil)
+ tsingleton x = let c = tsingleton x in RQ c SNil (toAnyConsList c)
  (RQ f r a) |> x = queue f (r `Snoc` x) a
 
  tviewl (RQ CNil SNil CNil) = TAEmptyL
  tviewl (RQ (h `Cons` t) f a) = h :< queue t f a
 
- tmap phi (RQ a b c) = RQ (tmap phi a) (tmap phi b) (tmap phi c)
+ tmap phi (RQ a b c) = RQ (tmap phi a) (tmap phi b) (toAnyConsList c)
 
 instance Category (FastQueue c) where
   id = tempty

--- a/type-aligned.cabal
+++ b/type-aligned.cabal
@@ -15,6 +15,7 @@ Tested-With:         GHC==7.6.3
 Library
   Build-Depends: base >= 2 && <= 6
   Exposed-modules: Data.TASequence.BinaryTree, Data.TASequence, Data.TASequence.ConsList, Data.TASequence.FastCatQueue,  Data.TASequence.FastQueue, Data.TASequence.FingerTree, Data.TASequence.Queue, Data.TASequence.SnocList, Data.TASequence.ToCatQueue
+  Other-modules: Data.TASequence.Any
 
   Extensions:	 GADTs, ViewPatterns, TypeOperators, Rank2Types
 


### PR DESCRIPTION
Use a sort of fake existential type for the schedule. This allows
GHC to unpack the queues. It also lets us avoid mapping over the
schedule it `tmap`, improving efficiency.