### PR TITLE
Generalize toAnyConsList

### DIFF
--- a/Data/TASequence/Any.hs
+++ b/Data/TASequence/Any.hs
@@ -19,6 +19,7 @@
 module Data.TASequence.Any
   ( Any
   , AnyCat
+  , toAny
   , toAnyConsList
   ) where
 
@@ -41,6 +42,10 @@ type family Any'
 
 newtype AnyCat a b = AnyCat Any
 
--- | Convert a list of anything to a list of 'Any'.
-toAnyConsList :: ConsList tc a c -> ConsList AnyCat Any c
+-- | Convert anything to 'AnyCat'.
+toAny :: c x y -> AnyCat x y
+toAny = unsafeCoerce
+
+-- | Convert a list of anything to a list of 'AnyCat'.
+toAnyConsList :: ConsList tc a c -> ConsList AnyCat d e
 toAnyConsList = unsafeCoerce

--- a/type-aligned.cabal
+++ b/type-aligned.cabal
@@ -16,7 +16,16 @@ Tested-With:         GHC ==7.4.2 GHC ==7.6.3 GHC ==7.8.4 GHC ==7.10.3 GHC ==8.0.
 Library
   Default-Language: Haskell2010
   Build-Depends: base >= 2 && <= 6
-  Exposed-modules: Data.TASequence.BinaryTree, Data.TASequence, Data.TASequence.ConsList, Data.TASequence.FastCatQueue,  Data.TASequence.FastQueue, Data.TASequence.FingerTree, Data.TASequence.Queue, Data.TASequence.SnocList, Data.TASequence.ToCatQueue
+  Exposed-modules:
+      Data.TASequence.BinaryTree
+    , Data.TASequence
+    , Data.TASequence.ConsList
+    , Data.TASequence.FastCatQueue
+    , Data.TASequence.FastQueue
+    , Data.TASequence.FingerTree
+    , Data.TASequence.Queue
+    , Data.TASequence.SnocList
+    , Data.TASequence.ToCatQueue
   Other-modules: Data.TASequence.Any
 
   Other-Extensions: GADTs, ViewPatterns, TypeOperators, RankNTypes, PolyKinds


### PR DESCRIPTION
* There are operations that want a more general type of
  `toAnyConsList` for optimal performance. Generalize it
  as far as is safe.
* Reformat the Cabal file slightly.